### PR TITLE
modify pages and widgets tag types

### DIFF
--- a/specs/manifest/index.html
+++ b/specs/manifest/index.html
@@ -138,7 +138,7 @@
 </td></tr>
 <tr>
 <td> pages </td>
-<td> Object </td>
+<td> Array </td>
 <td> 是 </td>
 <td> 路由信息
 </td></tr>
@@ -150,7 +150,7 @@
 </td></tr>
 <tr>
 <td> widgets </td>
-<td> Object </td>
+<td> Array </td>
 <td> 否 </td>
 <td> 卡片配置
 </td></tr></tbody><tfoot></tfoot></table>


### PR DESCRIPTION
The pages and widgets tag may contain multiple members, so an array type is required instead of an object type.